### PR TITLE
supported log_level option

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -60,7 +60,7 @@ sub run {
         host                       => $host,
         proto                      => $proto,
         serialize                  => 'flock',
-        log_level                  => DEBUG ? 4 : 2,
+        log_level                  => defined $options->{log_level} ? $options->{log_level} : DEBUG ? 4 : 2,
         min_servers                => $options->{min_servers}       || $workers,
         min_spare_servers          => $options->{min_spare_servers} || $workers - 1,
         max_spare_servers          => $options->{max_spare_servers} || $workers - 1,


### PR DESCRIPTION
Test の時などに、log_level を 0 にしたかったので、option から渡せるようにしました。

```
Plack::Loader->load( 'Starman',
    host          => '127.0.0.1',
    port          => $port,
    log_level     => 0,
    'max-workers' => 1,
)->run($app);
```
