### PR TITLE
Keepalive timeout

### DIFF
--- a/bin/starman
+++ b/bin/starman
@@ -137,6 +137,17 @@ if you run Starman behind a broken frontend proxy that tries to pool
 connections more than a number of backend workers (i.e. Apache
 mpm_prefork + mod_proxy).
 
+=item --keepalive-timeout
+
+The number of seconds Starman will wait for a subsequent request
+before closing the connection if Keep-alive persistent connections
+are enabled. Setting this to a high value may cause performance
+problems in heavily loaded servers. The higher the timeout, the
+more backend workers will be kept occupied waiting on connections
+with idle clients.
+
+Defaults to 1.
+
 =item --user
 
 To listen on a low-numbered (E<lt>1024) port, it will be necessary to

--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -37,6 +37,9 @@ sub run {
     if (! exists $options->{keepalive}) {
         $options->{keepalive} = 1;
     }
+    if (! exists $options->{keepalive_timeout}) {
+        $options->{keepalive_timeout} = 1;
+    }
 
     my($host, $port, $proto);
     for my $listen (@{$options->{listen} || [ "$options->{host}:$options->{port}" ]}) {
@@ -251,7 +254,7 @@ sub process_request {
             DEBUG && warn "[$$] Waiting on previous connection for keep-alive request...\n";
 
             my $sel = IO::Select->new($conn);
-            last unless $sel->can_read(1);
+            last unless $sel->can_read($self->{options}->{keepalive_timeout});
         }
     }
 


### PR DESCRIPTION
Hi Miyagawa,

Thanks for a fab web server, it's now serving my recipes on www.astray.com behind a Varnish cache. However, I noticed the default keepalive timeout is 1 second, which means Varnish was creating lots of connections to Starman for no reason. I've now made it an option with docs. I've upped it to 60 seconds as I'm behind Varnish and it all looks good. (I note Apache defaults to 5 seconds).

Cheers, Leon
