### PR TITLE
Net::Server doesn't like being passed a bare *STDERR handle.

### DIFF
--- a/bin/starman
+++ b/bin/starman
@@ -171,6 +171,11 @@ Defaults to the current group id.
 Specify the pid file path. Use it with C<-D|--daemonize> option,
 described in C<plackup -h>.
 
+=item --error-log
+
+Specify the pathname of a file where the error log should be written.
+This enables you to still have access to the errors when using C<--daemonize>.
+
 =back
 
 Starman passes through other options given to L<Plack::Runner>, the

--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -68,7 +68,7 @@ sub run {
         proto                      => $proto,
         serialize                  => 'flock',
         log_level                  => DEBUG ? 4 : 2,
-        log_file                   => $options->{error_log}         || *STDERR,
+        ($options->{error_log} ? ( log_file => $options->{error_log} ) : () ),
         min_servers                => $options->{min_servers}       || $workers,
         min_spare_servers          => $options->{min_spare_servers} || $workers - 1,
         max_spare_servers          => $options->{max_spare_servers} || $workers - 1,


### PR DESCRIPTION
Add error-log documentation to the starman bin.

All tests now passing as in master.
