### PR TITLE
Fix for issue #23

### DIFF
--- a/t/chunked_res.t
+++ b/t/chunked_res.t
@@ -1,0 +1,54 @@
+use strict;
+use Plack::Test;
+use HTTP::Request;
+use Test::More;
+use IO::Socket qw(:crlf);
+
+$Plack::Test::Impl = "Server";
+$ENV{PLACK_SERVER} = 'Starman';
+
+my @app = (
+    sub {
+        my $env = shift;
+        return sub {
+            my $response = shift;
+            my $writer = $response->([ 200, [ 'Content-Type', 'text/plain' ]]);
+            $writer->write("This is the data in the first chunk${CRLF}");
+            $writer->write("and this is the second one${CRLF}");
+            $writer->write("con");
+            $writer->write("sequence");
+            $writer->close;
+        }
+    },
+    sub {
+        my $env = shift;
+        return sub {
+            my $response = shift;
+            my $writer = $response->([
+                200, [ 'Content-Type', 'text/plain', 'Transfer-Encoding', 'chunked' ]
+            ]);
+            $writer->write("25${CRLF}This is the data in the first chunk${CRLF}${CRLF}");
+            $writer->write("1C${CRLF}and this is the second one${CRLF}${CRLF}");
+            $writer->write("3${CRLF}con${CRLF}");
+            $writer->write("8${CRLF}sequence${CRLF}");
+            $writer->write("0${CRLF}${CRLF}");
+            $writer->close;
+        }
+    },
+);
+
+for my $app (@app) {
+    test_psgi $app, sub {
+        my $cb = shift;
+
+        my $req = HTTP::Request->new(GET => "http://localhost/");
+        my $res = $cb->($req);
+
+        is $res->content,
+            "This is the data in the first chunk\r\n" .
+            "and this is the second one\r\n" .
+            "consequence";
+    };
+}
+
+done_testing;


### PR DESCRIPTION
Hope it's OK that way.

I removed this section entirely:

```
    elsif ( my $te = $headers{'transfer-encoding'} ) {
        if ( $te eq 'chunked' ) {
            DEBUG && warn "[$$] Chunked transfer-encoding set for response\n";
            $chunked = 1;
        }
    }
```

"Transfer-Encoding: chunked" + "Content-Length" does not make sense IMHO,
but anyway - if "Transfer-Encoding: chunked" already exists in the header, we should
assume, that the body is already properly chunked.

Bernhard
