### PR TITLE
Transfer-Encoding chunked in response to a HEAD request send additional data

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -455,7 +455,7 @@ sub _finalize_response {
 
     if ( $protocol eq 'HTTP/1.1' ) {
         if ( !exists $headers{'content-length'} ) {
-            if ( $status !~ /^1\d\d|[23]04$/ ) {
+            if ( $status !~ /^1\d\d|[23]04$/ and $env->{REQUEST_METHOD} ne 'HEAD' ) {
                 DEBUG && warn "[$$] Using chunked transfer-encoding to send unknown length body\n";
                 push @headers, 'Transfer-Encoding: chunked';
                 $chunked = 1;


### PR DESCRIPTION
Hello,

after a HEAD request and a response without an explicit Content-Length header, Starman send the response to the client with a transfer-encoding of chunked. As the body is empty that puts a additional zero on the line. RFC 2616 explicitly states in 4.4.1 that a HEAD request is terminated by an empty line after the headers. Although most clients can obviously live with that, Apache with mod_proxy gets confused and adds this zero to another request, leading to corrupt responses. This patch fixes the problem at least in my test case.

Best wishes and thanks for Starman,

Mario
