### PR TITLE
make plack's lint happy when using unix sockets

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -55,7 +55,7 @@ sub run {
             push @$port, $p;
             push @$proto, 'tcp';
         } else {
-            push @$host, 'localhost';
+            push @$host, 'unix/';
             push @$port, $listen;
             push @$proto, 'unix';
         }
@@ -176,8 +176,8 @@ sub process_request {
         my $env = {
             REMOTE_ADDR     => $self->{server}->{peeraddr},
             REMOTE_HOST     => $self->{server}->{peerhost} || $self->{server}->{peeraddr},
-            SERVER_NAME     => $self->{server}->{sockaddr}, # XXX: needs to be resolved?
-            SERVER_PORT     => $self->{server}->{sockport},
+            SERVER_NAME     => $self->{server}->{host}->[0],
+            SERVER_PORT     => $self->{server}->{port}->[0],
             SCRIPT_NAME     => '',
             'psgi.version'      => [ 1, 1 ],
             'psgi.errors'       => *STDERR,


### PR DESCRIPTION
Fixes "Missing mandatory env param: SERVER_NAME"
