### PR TITLE
Set REMOTE_PORT environment variable

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -176,6 +176,7 @@ sub process_request {
         my $env = {
             REMOTE_ADDR     => $self->{server}->{peeraddr},
             REMOTE_HOST     => $self->{server}->{peerhost} || $self->{server}->{peeraddr},
+            REMOTE_PORT     => $self->{server}->{peerport} || 0,
             SERVER_NAME     => $self->{server}->{sockaddr} || 0, # XXX: needs to be resolved?
             SERVER_PORT     => $self->{server}->{sockport} || 0,
             SCRIPT_NAME     => '',


### PR DESCRIPTION
REMOTE_PORT is a useful environment variable which can help ie. to track requests from the same user's session. It is not defined in RFC3875 but is commonly adapted by webservers.
