### PR TITLE
bin/starman: set shebang to /usr/bin env perl

### DIFF
--- a/bin/starman
+++ b/bin/starman
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use Plack::Runner;
 


### PR DESCRIPTION
Change the shebang to "#!/usr/bin env perl" for convenience for users
with custom perls in their $PATH. This'll presumably be overwritten by
the installation process so it only affects running it from a
checkout.
