### PR TITLE
Do not send a chunked body for HEAD requests

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -473,7 +473,7 @@ sub _finalize_response {
 
     if ( $protocol eq 'HTTP/1.1' ) {
         if ( !exists $headers{'content-length'} ) {
-            if ( $status !~ /^1\d\d|[23]04$/ ) {
+            if ( $status !~ /^1\d\d|[23]04$/ && $env->{REQUEST_METHOD} ne 'HEAD' ) {
                 DEBUG && warn "[$$] Using chunked transfer-encoding to send unknown length body\n";
                 push @headers, 'Transfer-Encoding: chunked';
                 $chunked = 1;

--- a/t/no_chunked_head.t
+++ b/t/no_chunked_head.t
@@ -1,0 +1,48 @@
+use strict;
+use Test::TCP;
+use IO::Socket::INET;
+use HTTP::Request;
+use HTTP::Response;
+use Plack::Loader;
+use Test::More;
+
+$ENV{PLACK_SERVER} = 'Starman';
+
+test_tcp(
+    client => sub {
+        my $port = shift;
+
+        my $socket = IO::Socket::INET->new(
+            PeerAddr => 'localhost',
+            PeerPort => $port,
+            Proto => 'tcp'
+        ) or die "Failed to connect to server: $!";
+
+        my $request = HTTP::Request->new(
+            HEAD => '/', [ Host => 'localhost' ]
+        );
+        $request->protocol('HTTP/1.1');
+
+        $socket->send($request->as_string("\r\n"));
+        $socket->shutdown(1);
+
+        my $data;
+        while ($socket->connected) {
+            my $buf;
+            $socket->recv($buf, 1024);
+            $data .= $buf;
+        }
+
+        my $res = HTTP::Response->parse($data);
+
+        is $res->content, '';
+    },
+    server => sub {
+        my $port = shift;
+        my $server = Plack::Loader->auto(port => $port, host => '127.0.0.1');
+
+        $server->run(sub { return [ 200, [], [] ] });
+    }
+);
+
+done_testing;


### PR DESCRIPTION
The HTTP 1.1 spec states

The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response

If a Plack app does not set a body or a Content-Length for a response to a HEAD request (which I believe is correct), Starman currently enables chunked encoding and sends the chunked 'footer' in the body of the response.  I believe this contradicts the spec (as above) and causes problems with my (nodejs) client.

Server.pm already disables chunked responses for status codes without a body (204 and 304) - this patch does the same for HEAD requests.

The test fails without the patch to the .pm, it has to use the low level IO::Socket::INET so we get the body before the chunked decoding is applied
