### PR TITLE
Added child communication forwarding to Net::Server::PreFork

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -59,6 +59,9 @@ sub run {
     if (! exists $options->{keepalive_timeout}) {
         $options->{keepalive_timeout} = 1;
     }
+    if ( $options->{child_communication} ) {
+        $extra{child_communication} = 1;
+    }
 
     my @port;
     for my $listen (@{$options->{listen} || [ "$options->{host}:$options->{port}" ]}) {


### PR DESCRIPTION
Added child_communication forwarding from Starman to Net::Server::Prefork.
It is required for child_is_talking_hook.
