### PR TITLE
Expect comparsion should be case insensitive

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -249,7 +249,7 @@ sub process_request {
 
             # Do we need to send 100 Continue?
             if ( $env->{HTTP_EXPECT} ) {
-                if ( $env->{HTTP_EXPECT} eq '100-continue' ) {
+                if ( lc $env->{HTTP_EXPECT} eq '100-continue' ) {
                     _syswrite($conn, \('HTTP/1.1 100 Continue' . $CRLF . $CRLF));
                     DEBUG && warn "[$$] Sent 100 Continue response\n";
                 }


### PR DESCRIPTION
From RFC 2616:

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20

"Comparison of expectation values is case-insensitive for unquoted
tokens (including the 100-continue token), and is case-sensitive for
quoted-string expectation-extensions."

From RFC 7231:

http://tools.ietf.org/html/rfc7231#section-5.1.1

"The Expect field-value is case-insensitive."
