### PR TITLE
Make READ_TIMEOUT be configurable instead via --read-timeout

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -16,7 +16,6 @@ use Plack::TempBuffer;
 
 use constant DEBUG        => $ENV{STARMAN_DEBUG} || 0;
 use constant CHUNKSIZE    => 64 * 1024;
-use constant READ_TIMEOUT => 5;
 
 my $null_io = do { open my $io, "<", \""; $io };
 
@@ -58,6 +57,9 @@ sub run {
     }
     if (! exists $options->{keepalive_timeout}) {
         $options->{keepalive_timeout} = 1;
+    }
+    if (! exists $options->{read_timeout}) {
+        $options->{read_timeout} = 5;
     }
     if (! exists $options->{proctitle}) {
         $options->{proctitle} = 1;
@@ -325,7 +327,7 @@ sub _read_headers {
     eval {
         local $SIG{ALRM} = sub { die "Timed out\n"; };
 
-        alarm( READ_TIMEOUT );
+        alarm( $self->{options}->{read_timeout} );
 
         while (1) {
             # Do we have a full header in the buffer?

--- a/script/starman
+++ b/script/starman
@@ -169,6 +169,17 @@ with idle clients.
 
 Defaults to 1.
 
+=item --read-timeout
+
+The number of seconds Starman will wait for a request on a new connection
+before closing it. Setting this to a high value may cause performance
+problems in heavily loaded servers. The higher the timeout, the
+more backend workers will be kept occupied waiting on connections
+with idle clients. You may need this if your proxy / load balancer likes to
+keep a pool of open connections while waiting for clients (eg. Amazon ELB).
+
+Defaults to 5.
+
 =item --user
 
 To listen on a low-numbered (E<lt>1024) port, it will be necessary to


### PR DESCRIPTION
This is in regards to Issue #102
