### PR TITLE
Net::Server has support for Log4perl, which means by extension that Star...

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -46,6 +46,18 @@ sub run {
     if ( DEBUG ) {
         $extra{log_level} = 4;
     }
+
+    # Options for Net::Server's Log4perl support
+    if ( $options->{log4perl_conf} ) {
+        $extra{log4perl_conf} = $options->{log4perl_conf};
+    }
+    if ( $options->{log4perl_logger} ) {
+        $extra{log4perl_logger} = $options->{log4perl_logger};
+    }
+    if ( $options->{log4perl_poll} ) {
+        $extra{log4perl_poll} = $options->{log4perl_poll};
+    }
+
     if ( $options->{ssl_cert} ) {
         $extra{SSL_cert_file} = $options->{ssl_cert};
     }


### PR DESCRIPTION
...man could have it as well. However, Starman doesn't pass the options down to Net::Server that it needs. This patch adds those. Thanks in advance for your consideration.

--Andrew