### PR TITLE
Changed --listen parsing to use Net::Server::Proto->parse_info()

### DIFF
--- a/META.json
+++ b/META.json
@@ -51,6 +51,7 @@
       "test" : {
          "requires" : {
             "LWP::UserAgent" : "0",
+            "Test::MockModule" : "0",
             "Test::More" : "0",
             "Test::Requires" : "0"
          }

--- a/t/proto.t
+++ b/t/proto.t
@@ -1,0 +1,44 @@
+use strict;
+use Test::More;
+use Test::Requires { 'LWP::Protocol::https' => 6 };
+use Test::TCP;
+use LWP::UserAgent;
+use FindBin '$Bin';
+use Starman::Server;
+
+use Test::MockModule;
+
+my $module = Test::MockModule->new( 'Net::Server::PreFork' );
+
+my @last_args;
+
+$module->mock( 'run', sub {
+               @last_args = @_;
+               return;
+});
+
+
+Starman::Server->new()->run( 'Starman', {
+                             listen => [
+                                    ':80',
+                                    '1.2.3.4:123:ssl',
+                                    '5.6.7.8:124/My::Custom::Proto',
+                                    '5.6.7.8:5001:ssleay/ipv6',
+                                    '/tmp/starman.sock|unix',
+                                    ]
+                                    }                                   
+);
+
+my $server = shift @last_args;
+my %opts = @last_args;
+my $ports = $opts{'port'};
+
+is_deeply( $ports, [
+           { ipv => 4,   port => 80,   proto => 'tcp', host => '0.0.0.0' },
+           { ipv => 4,   port => 123,  proto => 'ssl', host => '1.2.3.4' },
+           { ipv => 4,   port => 124,  proto => 'My::Custom::Proto', host => '5.6.7.8' },
+           { ipv => 6,   port => 5001, proto => 'ssleay',            host => '5.6.7.8' },
+           { ipv => '*', port => '/tmp/starman.sock', proto => 'unix',              host => '*' },
+            ], 'Expected ports' ) or diag explain $ports;
+
+done_testing;


### PR DESCRIPTION
Per the title, I ran into a situation where I wanted to use my own custom implementation of `Net::Server::Proto::SSL` that allowed me to hook into the handshake process. The standard `Net::Server:Proto::parse_info` method supports port specifications in string format that allow you to specify your own custom protocol package, eg in a form like this:

````
1.2.3.4:80/My::Custom::Proto
````

See perldoc for `Net::Server::Proto` for more examples.

I thought it would be good to have this same flexibility in the --listen option for Starman, which was a half-way solution that duplicated a subset of the functionality that was already in `Net::Server::Proto`. Hence this PR.

The only disadvantage of this PR that I can see is that the syntax for specifying Unix-domain sockets is slightly different:

````
# Old style
--listen /tmp/starman.sock
# New style
--listen /tmp/starman.sock|unix
````

So the price of the more efficient code is a slight loss of backward compatibility. It would probably be possible to add the new functionality while maintaining backwards compatibility, but this will make the code slightly more complicated again. If the maintainers of this package decide that backwards compatibility is important enough to try and keep, I can re-introduce it and re-submit a new pull request. Otherwise I'm happy for it to be used as-is.

Thoughts?