### PR TITLE
Fixed concurrent modification bug in hash iterator for net_server_args

### DIFF
--- a/lib/Plack/Handler/Starman.pm
+++ b/lib/Plack/Handler/Starman.pm
@@ -15,10 +15,12 @@ sub run {
         @Starman::Server::ISA = qw(Net::Server::SS::PreFork); # Yikes.
     }
 
+    my %nsa;
     while (my($key, $value) = each %$self) {
         $key =~ s/^net_server_// or next;
-        $self->{net_server_args}{$key} = $value;
+        $nsa{$key} = $value;
     }
+    $self->{net_server_args} = \%nsa if %nsa;
 
     Starman::Server->new->run($app, {%$self});
 }


### PR DESCRIPTION
I was alerted to this by warnings on my console during testing.

The code in `Plack::Handler::Starman` that implemented #111 was attempting to modify the $self hash (adding the `net_server_args` entry) while iterating over it using `each`. This causes the iterator to become undefined because the insertion of a new element can change the iterator order. Fixed by accumulating all the options in a sub-hash first, and then adding the sub-hash (if non-empty) when the iteration is complete.