### PR TITLE
Treat ECONNRESET like EPIPE (i.e. ignore), not as a fatal error.

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -8,7 +8,7 @@ use IO::Socket qw(:crlf);
 use HTTP::Parser::XS qw(parse_http_request);
 use HTTP::Status qw(status_message);
 use HTTP::Date qw(time2str);
-use POSIX qw(EINTR EPIPE);
+use POSIX qw(EINTR EPIPE ECONNRESET);
 use Symbol;
 
 use Plack::Util;
@@ -567,6 +567,7 @@ sub _syswrite {
 
         if (not defined $len) {
             return if $! == EPIPE;
+            return if $! == ECONNRESET;
             redo if $! == EINTR;
             die "write error: $!";
         }


### PR DESCRIPTION
If the client closed the connection before reading all the data,
or there's a network failure that results in the connection being reset,
we shouldn't treat that as a fatal error. It's much more like EPIPE
so now we treat it that way.