### PR TITLE
Added options to pass 'Log::Log4perl' as logger to Net::Server

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -47,6 +47,22 @@ sub run {
     }
     if ( $options->{error_log} ) {
         $extra{log_file} = $options->{error_log};
+
+        if ( $extra{log_file} == 'Log::Log4perl' ) {
+            if (! exists $options->{log4perl_conf}) {
+                die "log4perl_conf option must be provided";
+            } else {
+                $extra{log4perl_conf} = $options->{log4perl_conf};
+            }
+
+            if ( exists $options->{log4perl_poll}) {
+                $extra{log4perl_poll} = $options->{log4perl_poll};
+            }
+
+            if ( $options->{log4perl_logger} ) {
+                $extra{log4perl_logger} = $options->{log4perl_logger};
+            }
+        }
     }
     if ( DEBUG ) {
         $extra{log_level} = 4;


### PR DESCRIPTION
As Net::Server is able to use Log::Log4perl as logger, we can leverage it and use some of the advanced options that Log4perl provides.
For instance,  a USR1 signal can be used to recreate the logs (hello logrotate). Here an example:

```perl
use strict;
use warnings;
use Plack::Handler::Starman;
use Plack::Builder;

$SIG{'USR1'} = 'IGNORE';

sub start {
        my $app = sub {
                die 'Hello World crashed!!!';
        };
        builder {
                mount '/' => builder { $app; };
        }
}

my $log_config = {
        "log4perl.rootLogger" => "INFO,LOGFILE",
        "log4perl.appender.LOGFILE" => "Log::Log4perl::Appender::File",
        "log4perl.appender.LOGFILE.filename" => "/var/log/test.log",
        "log4perl.appender.LOGFILE.layout"   => "Log::Log4perl::Layout::PatternLayout",
        "log4perl.appender.LOGFILE.layout.ConversionPattern" => "[%r] %F %L %m%n",
        "log4perl.appender.LOGFILE.recreate" => 1,
        "log4perl.appender.Logfile.recreate_check_signal" => "USR1"
};

my $server = Plack::Handler::Starman->new(listen => ["127.0.0.1:8080"], daemonize => 1, error_log => 'Log::Log4perl', log4perl_conf => $log_config);
$server->run(start());
```

With that example, you can remove /var/log/test.log, send a USR1 signal to the master process and the file will be recreated.