### PR TITLE
implement --max-keepalive-requests (issue #124)

### DIFF
--- a/script/starman
+++ b/script/starman
@@ -122,6 +122,16 @@ failover (see above).
 
 Number of the requests to process per one worker process. Defaults to 1000.
 
+Note that "requests" actually means "connections served by a worker".
+In presence of Keep-alive a worker process can actually serve more
+requests; this can only be limited with the
+C<--max-keepalive-requests> option.
+
+=item --max-keepalive-requests
+
+Maximum number of Keep-alive requests served for a connection. By
+default there's no limit.
+
 =item --preload-app
 
 This option lets Starman preload the specified PSGI application in the


### PR DESCRIPTION
No tests for this change. One problem is that test_psgi() does not offer an easy way to set the server options (or I did not found out how). Here's a seperate commit which implements a test with too much code for my taste: https://github.com/eserte/Starman/commit/0dbde80b8c3f889ef71b3cc07c30842db6945223

The change may be manually tested using strace:
* start the server with your favorite app and some --max-keepalive-requests and --max-requests setting:
```
perl -Mblib script/starman --max-keepalive-requests=7 --max-requests=3 your_favorite.psgi
```
* run a keep-alive client with strace just filtering the connect() syscalls --- depending on the server configuration there should be just one connect() to the server (no --max-keepalive-requests setting, --max-requests setting irrelevant) or many connect() calls
```
strace -econnect perl -MLWP::UserAgent -e '$ua=LWP::UserAgent->new(keep_alive=>1); for (1..9) { die if !$ua->get("http://localhost:5000")->is_success }'
```