### PR TITLE
Skip dumping the buffer in STARMAN_DEBUG=1

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -2,7 +2,7 @@ package Starman::Server;
 use strict;
 use base 'Net::Server::PreFork';
 
-use Data::Dump qw(dump);
+use Data::Dump;
 use Socket qw(IPPROTO_TCP TCP_NODELAY);
 use IO::Socket qw(:crlf);
 use HTTP::Parser::XS qw(parse_http_request);
@@ -15,11 +15,20 @@ use Plack::Util;
 use Plack::TempBuffer;
 
 use constant DEBUG        => $ENV{STARMAN_DEBUG} || 0;
+use constant DEBUG_BUF    => (DEBUG >= 2);
 use constant CHUNKSIZE    => 64 * 1024;
 
 my $null_io = do { open my $io, "<", \""; $io };
 
 use Net::Server::SIG qw(register_sig);
+
+sub dump_buffer($) {
+    if (DEBUG_BUF) {
+        Data::Dump::dump($_[0]);
+    } else {
+        return "(" . length($_[0]) . " bytes of data)";
+    }
+}
 
 # Override Net::Server's HUP handling - just restart all the workers and that's about it
 sub sig_hup {
@@ -305,7 +314,7 @@ sub process_request {
                 if ( $self->{client}->{inputbuf} =~ /^(?:GET|HEAD)/ ) {
                     if ( DEBUG ) {
                         warn "Pipelined GET/HEAD request in input buffer: "
-                            . dump( $self->{client}->{inputbuf} ) . "\n";
+                            . dump_buffer( $self->{client}->{inputbuf} ) . "\n";
                     }
 
                     # Continue processing the input buffer
@@ -315,7 +324,7 @@ sub process_request {
                     # Input buffer just has junk, clear it
                     if ( DEBUG ) {
                         warn "Clearing junk from input buffer: "
-                            . dump( $self->{client}->{inputbuf} ) . "\n";
+                            . dump_buffer( $self->{client}->{inputbuf} ) . "\n";
                     }
 
                     $self->{client}->{inputbuf} = '';
@@ -354,7 +363,7 @@ sub _read_headers {
             }
 
             if ( DEBUG ) {
-                warn "[$$] Read $read bytes: " . dump($buf) . "\n";
+                warn "[$$] Read $read bytes: " . dump_buffer($buf) . "\n";
             }
 
             $self->{client}->{inputbuf} .= $buf;

--- a/script/starman
+++ b/script/starman
@@ -230,8 +230,12 @@ common backend that L<plackup> uses, so the most options explained in
 C<plackup -h> such as C<--access-log> or C<--daemonize> works fine in
 starman too.
 
-Setting the environment variable C<STARMAN_DEBUG> to 1 makes the
-Starman server running in the debug mode.
+Setting the environment variable C<STARMAN_DEBUG> to 1 or larger makes
+the Starman server running in the debug mode.
+
+Since version 0.4015, setting C<STARMAN_DEBUG> to 1 will not dump the
+content of the request buffer besides its size information. To get the
+full dump output, you have to set the value to 2 or larger.
 
 =cut
 


### PR DESCRIPTION
Starman debug mode prints the request header and body to the console, and enabling it on production could cause an incident where unwanted private information is logged. meanwhile, the other information displayed with the debug option could be still useful to monitor on a production environment.

This PR adds a new value of `STARMAN_DEBUG=2` to enable request buffer logging, while `STARMAN_DEBUG=1` will skip printing the request buffer. This is a breaking change if someone relies on the debug option printing the full request buffer to STDERR, but i would consider it's a reasonable change since it is explicitly named "debug" and we'll make sure to document it in Changes.