### PR TITLE
Corrected the logic to take into account max_requests with keep-alive connections

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -185,6 +185,7 @@ sub post_accept_hook {
         headerbuf => '',
         inputbuf  => '',
         keepalive => 1,
+        keepalive_requests => 0,
     };
 }
 
@@ -215,6 +216,9 @@ sub process_request {
 
         # Read until we see all headers
         last if !$self->_read_headers;
+
+        $self->{client}->{keepalive_requests} += 1;
+        $self->{server}->{requests} += 1 if $self->{client}->{keepalive_requests} > 1;
 
         my $env = {
             REMOTE_ADDR     => $self->{server}->{peeraddr},
@@ -321,6 +325,8 @@ sub process_request {
                     $self->{client}->{inputbuf} = '';
                 }
             }
+
+            last if $self->max_requests_reached;
 
             DEBUG && warn "[$$] Waiting on previous connection for keep-alive request...\n";
 
@@ -516,7 +522,7 @@ sub _finalize_response {
     }
 
     # Should we keep the connection open?
-    if ( $self->{client}->{keepalive} ) {
+    if ( $self->{client}->{keepalive} && !$self->max_requests_reached ) {
         push @headers, 'Connection: keep-alive';
     } else {
         push @headers, 'Connection: close';
@@ -584,6 +590,11 @@ sub post_client_connection_hook {
     if ($self->{client}->{harakiri}) {
         exit;
     }
+}
+
+sub max_requests_reached {
+    my $self = shift;
+    return $self->{server}->{requests} >= $self->{server}->{max_requests};
 }
 
 1;


### PR DESCRIPTION
Hello,

i found situation where starman does not take into account the number of requests in keepalive connection which led to incorrect restart of the starman worker after random number of requests that is greather than max_request parameter.