### PR TITLE
Allow SSL when used under Server::Starter

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -133,6 +133,10 @@ sub maybe_upgrade_to_ssl {
         # To pass them to starman use e.g. --net_server_SSL_cipher_list
        $options->{net_server_args} ? %{ $options->{net_server_args} } : (),
 
+       # Newer versions of Net::Server >= 2.011 need this to postpone the SSL
+       # handshake.  Older versions ignore it and don't need it.
+       SSL_startHandshake => 0,
+
        SSL_server => 1,
     });
 

--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -110,8 +110,8 @@ sub run {
     );
 }
 
-# Called from Net::Server::SS::PreFork->pre_bind
-# when used under server_starter
+# When used under server_starter this is called from
+# Net::Server::SS::PreFork->pre_bind
 sub maybe_upgrade_to_ssl {
     my ($self, $sock, $ssl_this_port) = @_;
 
@@ -133,7 +133,7 @@ sub maybe_upgrade_to_ssl {
         # To pass them to starman use e.g. --net_server_SSL_cipher_list
        $options->{net_server_args} ? %{ $options->{net_server_args} } : (),
 
-       SSL_Server => 1,
+       SSL_server => 1,
     });
 
     $sock->NS_proto('SSL');


### PR DESCRIPTION
This commit goes along with a PR I'm submitting to
p5-Net-Server-SS-PreFork.
    
It allows you to run starman under start_server like this:
    
    start_server \
        --port 1.1.1.1:111 \
        --port 2.2.2.2:222 \
        -- \
        starman \
        --enable-ssl \
        --ssl_cert ./etc/ccard/kgoess7-sandbox-ccweb.crt \
        --ssl_key ./etc/ccard/kgoess7-sandbox-ccweb.key \
        --net_server_SSL_cipher_list whatever
    
Or instead of enabling SSL on all the ports, it can be done selectively
by adding the ":ssl" suffix to the individual "--port" arguments.
    
The maybe_upgrade_to_ssl function allows Net::Server::SS::PreFork's
pre_bind method to look at $self->{options}, which is where Starman::Server has
stashed the SSL arguments.
    
See also a PR I'm submitting to p5-Server-Starter that allows
start_server's --port argument to take an ":ssl" suffix, like "--port
IP:PORT:ssl".
