### PR TITLE
Handle EINTR when doing sysread calls

### DIFF
--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -348,7 +348,7 @@ sub _read_headers {
             last if $self->{client}->{inputbuf} ne '' && $self->{client}->{inputbuf} =~ /$CR?$LF$CR?$LF/s;
 
             # If not, read some data
-            my $read = sysread $self->{server}->{client}, my $buf, CHUNKSIZE;
+            my $read = _sysread($self->{server}->{client}, my $buf, CHUNKSIZE);
 
             if ( !defined $read || $read == 0 ) {
                 die "Read error: $!\n";
@@ -409,7 +409,7 @@ sub _prepare_env {
             my $chunk = delete $self->{client}->{inputbuf};
             return ($chunk, length $chunk);
         }
-        my $read = sysread $self->{server}->{client}, my($chunk), CHUNKSIZE;
+        my $read = _sysread($self->{server}->{client}, my($chunk), CHUNKSIZE);
         return ($chunk, $read);
     };
 
@@ -577,6 +577,13 @@ sub _syswrite {
         $offset += $len;
 
         DEBUG && warn "[$$] Wrote $len byte", ($len == 1 ? '' : 's'), "\n";
+    }
+}
+
+sub _sysread {
+    while (1) {
+        my $len = sysread $_[0], $_[1], $_[2];
+        return $len if defined $len || $! != EINTR;
     }
 }
 

--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -583,7 +583,7 @@ sub _syswrite {
 sub _sysread {
     while (1) {
         my $len = sysread $_[0], $_[1], $_[2];
-        return $len if defined $len || $! != EINTR;
+        return $len if defined $len or $! != EINTR;
     }
 }
 

--- a/t/eintr.t
+++ b/t/eintr.t
@@ -1,0 +1,74 @@
+use strict;
+use Starman::Server;
+use Plack::Test;
+use HTTP::Request;
+use Test::More;
+use File::Temp qw(tempfile);
+use Time::HiRes qw(sleep);
+
+my $fh = tempfile;
+$fh->autoflush(1);
+
+# When a child handles our request, write it's pid to the temp file
+{
+    no warnings 'redefine';
+    my $old_process_request = \&Starman::Server::process_request;
+    *Starman::Server::process_request = sub {
+        seek $fh, 0, 0;
+        print $fh $$;
+        goto &$old_process_request;
+    };
+}
+
+$Plack::Test::Impl = "Server";
+$ENV{PLACK_SERVER} = 'Starman';
+
+my $app = sub {
+    my $env = shift;
+    my $body;
+    my $clen = $env->{CONTENT_LENGTH};
+    while ($clen > 0) {
+        $env->{'psgi.input'}->read(my $buf, $clen) or last;
+        $clen -= length $buf;
+        $body .= $buf;
+    }
+    return [ 200, [ 'Content-Type', 'text/plain', 'X-Content-Length', $env->{CONTENT_LENGTH} ], [ $body ] ];
+};
+
+test_psgi $app, sub {
+    my $cb = shift;
+
+    my $c = 0;
+
+    my $req = HTTP::Request->new(POST => "http://localhost/");
+    $req->content(sub {
+        $c++;
+
+        # Send some chunked content
+        return "abcde" if $c == 1;
+
+        # Child should be processing request, get pid
+        seek $fh, 0, 0;
+        sysread $fh, my $pid, 100;
+
+        # Ensure child is waiting on a sysread
+        sleep 0.1;
+
+        kill 'HUP', $pid if $pid;
+
+        # Ensure child received HUP before sending more data
+        sleep 0.1;
+
+        # Now send it some more content
+        return "abcde" if $c <= 5;
+
+        return undef;
+    });
+
+    my $res = $cb->($req);
+
+    # We should have got 5 x 5 bytes or 25 bytes total
+    is $res->header('X-Content-Length'), 25;
+};
+
+done_testing;


### PR DESCRIPTION
Starman usually sets max_spare_servers to max_servers - 1, so in general Net::Server will not try and kill off spare servers.

However if you explicitly set max_spare_servers lower, then Net::Server::PreFork will attempt to do it's usual process management in coordinate_children(), which may end up calling kill_n_children() if there's excess children. This will send a HUP signal to some child processes to ask them to exit.

The code in Net::Server::PreFork tries to only do this for 'waiting' child processes, but notes this is racy. That should be fine, because the child should continue processing any request in progress, and then exit after finishing the request because done() will be true after run_client_connection() completes.

However Starman doesn't currently check the result of sysread() calls for EINTR, so if it receives a HUP while processing a request, the sysread() call returns undef, which ends up propogating up as an error message "Read error: Interrupted system call".

The correct solution here is to detect the EINTR response and redo the sysread() call to complete the entire request successfully, before the high layer exits the child.