### PR TITLE
Add systemd socket activation support

### DIFF
--- a/lib/Net/Server/Systemd/PreFork.pm
+++ b/lib/Net/Server/Systemd/PreFork.pm
@@ -1,0 +1,169 @@
+package Net::Server::Systemd::PreFork;
+
+use strict;
+use warnings;
+
+use Net::Server::PreFork;
+use Net::Server::Proto;
+use Net::Server::Proto::TCP;
+use Net::Server::Proto::UNIX;
+use Socket qw(AF_INET6);
+
+use base qw(Net::Server::PreFork);
+
+use constant SD_LISTEN_FDS_START => 3;
+
+sub pre_bind {
+    my $self = shift;
+    my $prop = $self->{server};
+
+    # Net::Server::Proto::TCP starts life inheriting from IO::Socket::INET (IPv4
+    # only). Normally its constructor (::object) swaps @ISA to an IPv6-capable
+    # class (IO::Socket::IP) at runtime. Since we bypass that constructor — we
+    # already have bound fds from systemd — we trigger the same swap here. This
+    # is a global, idempotent mutation; it's safe because all TCP sockets in
+    # this process need IPv6 support regardless.
+    @Net::Server::Proto::TCP::ISA = (Net::Server::Proto->ipv6_package($self))
+        if $Net::Server::Proto::TCP::ISA[0] eq 'IO::Socket::INET';
+
+    my $count = $ENV{LISTEN_FDS}
+        or $self->fatal("LISTEN_FDS not set");
+
+    # Validate LISTEN_PID if set and non-empty.
+    if (my $pid = $ENV{LISTEN_PID}) {
+        $pid == $$
+            or $self->fatal("LISTEN_PID ($pid) does not match our PID ($$)");
+    }
+
+    my $first_fd = $ENV{LISTEN_FDS_FIRST_FD} || SD_LISTEN_FDS_START;
+
+    for my $i (0 .. $count - 1) {
+        my $fd = $first_fd + $i;
+
+        # We use fdopen (not new_from_fd) because we need the socket to be a
+        # Net::Server::Proto::TCP object — it already has the NS_* accessor
+        # methods that Net::Server's event loop expects, and after the @ISA swap
+        # above it inherits from IO::Socket::IP which handles both IPv4 and IPv6
+        # accept/address parsing correctly.
+        my $sock = Net::Server::Proto::TCP->new();
+        $sock->fdopen($fd, 'r')
+            or $self->fatal("failed to fdopen listening socket fd $fd: $!");
+
+        # Detect the actual socket family so Net::Server knows how to format
+        # addresses in log messages, etc.
+        my $sockname = getsockname($sock)
+            or $self->fatal("getsockname failed on fd $fd: $!");
+        my $family = Socket::sockaddr_family($sockname);
+
+        if ($family == AF_INET6) {
+            $sock->NS_ipv('6');
+        } elsif ($family == Socket::AF_INET) {
+            $sock->NS_ipv('4');
+        } else {
+            # Not an IP socket — assume Unix domain. Re-fdopen into the correct
+            # Proto class since Proto::TCP can't handle Unix accept.
+            $sock = Net::Server::Proto::UNIX->new();
+            $sock->fdopen($fd, 'r')
+                or $self->fatal("failed to fdopen listening socket fd $fd: $!");
+        }
+
+        push @{$prop->{sock}}, $sock;
+    }
+
+    $prop->{multi_port} = 1 if @{$prop->{sock}} > 1;
+}
+
+# Override bind to skip actually binding (already done by systemd) and just set
+# up IO::Select if there are multiple listening sockets.
+sub bind {
+    my $self = shift;
+    my $prop = $self->{server};
+
+    if (@{$prop->{sock}} > 1) {
+        $prop->{multi_port} = 1;
+        $prop->{select} = IO::Select->new();
+        for (@{$prop->{sock}}) {
+            $prop->{select}->add($_);
+        }
+    } else {
+        $prop->{multi_port} = undef;
+        $prop->{select}     = undef;
+    }
+}
+
+# Use close(2) rather than shutdown(2). See Net::Server::SS::PreFork for
+# rationale — shutdown on a shared fd closes it for all forked workers.
+sub shutdown_sockets {
+    my $self = shift;
+    my $prop = $self->{server};
+
+    for my $sock (@{$prop->{sock}}) {
+        $sock->close;
+    }
+
+    $prop->{sock} = [];
+    return 1;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Net::Server::Systemd::PreFork - a Net::Server personality for systemd socket activation
+
+=head1 SYNOPSIS
+
+  # in a systemd .socket unit:
+  # [Socket]
+  # ListenStream=0.0.0.0:80
+
+  # in your server:
+  use base qw(Net::Server::Systemd::PreFork);
+
+  sub process_request {
+      #...code...
+  }
+
+  __PACKAGE__->run();
+
+=head1 DESCRIPTION
+
+C<Net::Server::Systemd::PreFork> is a L<Net::Server> personality, extending
+L<Net::Server::PreFork>, that accepts listening sockets passed by systemd
+via the C<LISTEN_FDS> protocol (socket activation).
+
+This is the systemd equivalent of L<Net::Server::SS::PreFork> (which does
+the same for L<Server::Starter>).
+
+=head1 ENVIRONMENT VARIABLES
+
+=over 4
+
+=item LISTEN_FDS
+
+Number of file descriptors passed by systemd (required).
+
+=item LISTEN_PID
+
+If set and non-empty, must match the current PID.
+
+=item LISTEN_FDS_FIRST_FD
+
+Override the first fd number (defaults to 3, the systemd standard).
+This is a non-standard extension supported by some tools (e.g. the
+C<listenfd> Rust crate) for cases where fds cannot be placed at 3.
+
+=back
+
+=head1 SEE ALSO
+
+L<Net::Server::PreFork>, L<Net::Server::SS::PreFork>, L<systemd.socket(5)>
+
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or modify it
+under the same terms as Perl itself.
+
+=cut

--- a/lib/Plack/Handler/Starman.pm
+++ b/lib/Plack/Handler/Starman.pm
@@ -13,6 +13,9 @@ sub run {
     if ($ENV{SERVER_STARTER_PORT}) {
         require Net::Server::SS::PreFork;
         @Starman::Server::ISA = qw(Net::Server::SS::PreFork); # Yikes.
+    } elsif ($ENV{LISTEN_FDS}) {
+        require Net::Server::Systemd::PreFork;
+        @Starman::Server::ISA = qw(Net::Server::Systemd::PreFork);
     }
 
     my %nsa;

--- a/lib/Starman/Server.pm
+++ b/lib/Starman/Server.pm
@@ -113,17 +113,27 @@ sub run {
 sub pre_loop_hook {
     my $self = shift;
 
-    my $port = $self->{server}->{port}->[0];
-    my $proto = $port->{proto} eq 'ssl'  ? 'https' :
-                $port->{proto} eq 'unix' ? 'unix'  :
-                                           'http';
+    my %ready = (server_software => 'Starman');
 
-    $self->{options}{server_ready}->({
-        host => $port->{host},
-        port => $port->{port},
-        proto => $proto,
-        server_software => 'Starman',
-    }) if $self->{options}{server_ready};
+    # Since by this point the socket has been opened, we can look at what we
+    # actually did, instead of merely what the configure said we were supposed
+    # to do.
+    if (my $sock = ($self->{server}->{sock} && $self->{server}->{sock}->[0])) {
+        $ready{proto} = $sock->isa('Net::Server::Proto::SSL')    ? 'https' :
+                        $sock->isa('Net::Server::Proto::UNIX')   ? 'unix'  :
+                                                                    'http';
+    }
+
+    if ($self->{server}->{port} && @{$self->{server}->{port}}) {
+        my $port = $self->{server}->{port}->[0];
+        $ready{host} = $port->{host};
+        $ready{port} = $port->{port};
+    } else {
+        $self->log(2, "Using socket activation");
+    }
+
+    $self->{options}{server_ready}->(\%ready)
+        if $self->{options}{server_ready};
 
     register_sig(
         TTIN => sub { $self->{server}->{$_}++ for qw( min_servers max_servers ) },


### PR DESCRIPTION
When `LISTEN_FDS` is set, Starman now accepts pre-bound listening sockets from systemd via the socket activation protocol, mirroring the existing `Server::Starter` support.

This is implemented as a new `Net::Server::Systemd::PreFork` personality that overrides `pre_bind` to grab fds from the environment instead of binding new sockets. `Plack::Handler::Starman` detects `LISTEN_FDS` and swaps in this personality, exactly as it does for `SERVER_STARTER_PORT`.

See systemd.socket(5) for socket unit configuration: https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html

The non-standard `LISTEN_FDS_FIRST_FD` extension is also supported: https://docs.rs/listenfd/latest/listenfd/

> This commit (and the above text) is vibe-coded; I do not know Starman or Perl that well. I did read it however, and I have been able to use it in a downstream project --- https://github.com/NixOS/hydra/pull/1703 --- successfully.